### PR TITLE
News欄→Talks欄への置き換え

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -117,7 +117,7 @@ gulp.task('pug', () => {
     sponsorEvents: readConfig(`${CONFIG}/sponsor-event.json`).sheet,
     events: readConfig(`${CONFIG}/event.json`).sheet,
     members: readConfig(`${CONFIG}/member.json`),
-    newsArr: readConfig(`${CONFIG}/news.yml`),
+    newsArr: readConfig(`${CONFIG}/talks.yml`),
     bibArr: bibtexParse.toJSON(fs.readFileSync(`${CONFIG}/publication.bib`, { encoding:"utf8" })),
     unescape: (body) => (
       // from [JavaScript：unescapeHTMLの妥当な実装: Architect Note](http://blog.tojiru.net/article/211339637.html)

--- a/src/config/talks.yml
+++ b/src/config/talks.yml
@@ -1,0 +1,175 @@
+-
+  time:
+    '2020-03-03'
+  update:
+    '<a href="https://speakerdeck.com/denjiry/ccgniji-duitelun-li-gou-zao-wozi-dong-jian-zheng-sururi-ben-yu-edeita">CCGに基づいて論理構造を自動検証する日本語エディタ（東北支部 勉強会）</a>'
+-
+  time:
+    '2019-11-29'
+  update:
+    '<a href="https://www.slideshare.net/yutaashihara3/ashihara-wb-awakatecasualtalk20191129">アフォーダンスの話（第45回カジュアルトーク）</a>'
+-
+  time:
+    '2019-11-29'
+  update:
+    '<a href="https://www.slideshare.net/RyoUeda2/45-199713042">不老不死について（第45回カジュアルトーク）</a>'
+-
+  time:
+    '2019-11-29'
+  update:
+    '<a href="https://www.slideshare.net/AkihikoFukuchi/ss-199701501">AIを騙す ~敵対的サンプル~（第45回カジュアルトーク）</a>'
+-
+  time:
+    '2019-11-29'
+  update:
+    '<a href="https://www.slideshare.net/hirotakamiura/enabling-control/hirotakamiura/enabling-control">会社は「従業員が自ら頑張る」仕組みをどのように作っているか（第45回カジュアルトーク）</a>'
+-
+  time:
+    '2019-06-19'
+  update:
+    '<a href="https://www.slideshare.net/YukiMinai/cognitive-science-for-the-development-of-human-like-ai">Human-like AI実現に向けた認知科学的アプロ―チ（第42回勉強会）</a>'
+-
+  time:
+    '2019-03-21'
+  update:
+    '<a href="https://www.slideshare.net/kinakotappuri/100web">100年前の「こころ」観（第3回異分野交流会）</a>'
+-
+  time:
+    '2019-03-21'
+  update:
+    '<a href="https://www.slideshare.net/hirotakamiura/from-book-to-human">帳簿から人間へ -管理会計は従業員の心理を見る-（第3回異分野交流会）</a>'
+-
+  time:
+    '2019-03-21'
+  update:
+    '<a href="https://speakerdeck.com/takuseno/aihajiao-etemorawanakerebahe-modekinaifalseka">AIは教えてもらわないと何もできないのか（第3回異分野交流会）</a>'
+-
+  time:
+    '2019-03-21'
+  update:
+    '<a href="https://www.slideshare.net/takumayagi/190321-2019-3">2019年 人工知能研究のこれまでとこれから（第3回異分野交流会）</a>'
+-
+  time:
+    '2018-06-10'
+  update:
+    '<a href="https://www.slideshare.net/KokiYasuda1/nn-101726527">NN時代の自然言語処理の設計と評価（第35回勉強会）</a>'
+-
+  time:
+    '2018-04-11'
+  update:
+    '<a href="https://www.slideshare.net/takumayagi/34-93528187">オープンワールド認識（第34回勉強会）</a>'
+-
+  time:
+    '2017-10-23'
+  update:
+    '<a href="https://www.slideshare.net/anry610/ss-81276833">心理学は人工知能に心を提供できるか（第33回勉強会）</a>'
+-
+  time:
+    '2017-09-04'
+  update:
+    '<a href="https://www.slideshare.net/takumayagi/connectionistgeneralization-79406596">コネクショニズムと汎化（第29回勉強会 哲学的人工知能批判と第3次AIブーム）</a>'
+-
+  time:
+    '2017-09-04'
+  update:
+    '<a href="https://www.slideshare.net/yukikawamura2/20170904-79405830">規則のパラドックスと合理性のありか（第29回勉強会 哲学的人工知能批判と第3次AIブーム）</a>'
+-
+  time:
+    '2017-09-04'
+  update:
+    '<a href="https://www.slideshare.net/YujiOgawa/ss-79406885">ドレイファスの批判とコネクショニズム以降の人工知能（第29回勉強会 哲学的人工知能批判と第3次AIブーム）</a>'
+-
+  time:
+    '2017-09-04'
+  update:
+    '<a href="https://www.slideshare.net/kotarosakamoto585/ss-79407553">楽観論と打ち砕かれた夢～哀れな人工知能研究者たち（第29回勉強会 哲学的人工知能批判と第3次AIブーム）</a>'
+-
+  time:
+    '2017-07-20'
+  update:
+    '<a href="https://speakerdeck.com/takuseno/survey-of-deep-reinforcement-learning">深層強化学習（第28回勉強会）</a>'
+-
+  time:
+    '2017-06-21'
+  update:
+    '<a href="https://www.slideshare.net/kentotajiri/ss-77136469">バイナリニューラルネットとハードウェアの関係（第26回勉強会）</a>'
+-
+  time:
+    '2017-06-07'
+  update:
+    '<a href="https://www.slideshare.net/osawamasahiko/24-76715878">ドラえもんとHuman-Agent Interaction（第24回カジュアルトーク）</a>'
+-
+  time:
+    '2017-05-31'
+  update:
+    '<a href="https://speakerdeck.com/ohto/arbitrariness-for-classification">分類するということ（第25回カジュアルトーク）</a>'
+-
+  time:
+    '2017-05-31'
+  update:
+    '<a href="https://www.slideshare.net/yuukiiwabuchi9/ss-76519489">明日機械学習に役立つかもしれない数学（第25回カジュアルトーク）</a>'
+-
+  time:
+    '2017-01-31'
+  update:
+    '<a href="https://www.slideshare.net/takahirokubo7792/tis-71583481">TISにおける、研究開発のメソッド（第20回カジュアルトーク）</a>'
+-
+  time:
+    '2017-01-31'
+  update:
+    '<a href="https://www.slideshare.net/sheemap/convolutional-neural-netwoks">CNNで自然言語処理をする（第20回カジュアルトーク）</a>'
+-
+  time:
+    '2017-01-31'
+  update:
+    '<a href="https://www.slideshare.net/HangyoMasatsugu/20170130-71583654">自然言語処理の沼へようこそ（第20回カジュアルトーク）</a>'
+-
+  time:
+    '2017-01-31'
+  update:
+    '<a href="http://pomdp.net/docs/zenno_20170131.pdf">End-to-End時代における対話システムの研究動向（第20回カジュアルトーク）</a>'
+-
+  time:
+    '2016-06-16'
+  update:
+    '<a href="https://www.slideshare.net/YurikaDoi/doi-63126093">実ロボットの運動生成（第15回勉強会）</a>'
+-
+  time:
+    '2016-05-14'
+  update:
+    '<a href="https://www.slideshare.net/takumayagi/probabilistic-graphical-models-1">Probabilistic Graphical Models 輪読会 #1 概要</a>'
+-
+  time:
+    '2016-03-11'
+  update:
+    '<a href="https://www.slideshare.net/yukinoguchi999/ss-59238906">言語と画像の表現学習（第13回勉強会）</a>'
+-
+  time:
+    '2015-11-19'
+  update:
+    '<a href="https://www.slideshare.net/narumikanno0918/11wba-55283892">スパースコーディングとその数理（第11回勉強会）</a>'
+-
+  time:
+    '2015-10-13'
+  update:
+    '<a href="https://www.slideshare.net/YumaMatsuoka/ss-53919112">海馬と記憶モデルの展望（第10回勉強会）</a>'
+-
+  time:
+    '2015-06-29'
+  update:
+    '<a href="https://www.slideshare.net/Erika_Fujita/ss-50118591">ベイジアンネットワーク（第7回勉強会）</a>'
+-
+  time:
+    '2015-06-29'
+  update:
+    '<a href="https://www.slideshare.net/Erika_Fujita/ss-50118591">ベイジアンネットワーク（第7回勉強会）</a>'
+-
+  time:
+    '2015-03-18'
+  update:
+    '<a href="https://www.slideshare.net/kwp_george/ss-45978508">強化学習 脳へのアプローチ（第4回勉強会）</a>'
+-
+  time:
+    '2014-11-13'
+  update:
+    '<a href="https://www.slideshare.net/takumayagi/rbm-andlearning">RBM、Deep Learningと学習（第3回勉強会）</a>'

--- a/src/pug/index.pug
+++ b/src/pug/index.pug
@@ -101,6 +101,10 @@ block content-block
           | Talk slides
         h4.sub-heading
           | これまでの発表資料
+        p.hover-effect
+            | これまで開催されたイベントについては
+            a.elm-a(href="http://wbawakate.connpass.com/", target="_blank") connpassページ
+            | も併せてご覧ください。
 
         ul.news-list.hover-effect
           each news in newsArr

--- a/src/pug/index.pug
+++ b/src/pug/index.pug
@@ -98,9 +98,9 @@ block content-block
     section.section-contents.sec-news
       .front-block
         h3.heading
-          | News
+          | Talk slides
         h4.sub-heading
-          | 新着情報
+          | これまでの発表資料
 
         ul.news-list.hover-effect
           each news in newsArr

--- a/src/scss/page/_home.scss
+++ b/src/scss/page/_home.scss
@@ -191,13 +191,13 @@
       margin-top: px(20);
 
       width: 100%;
-      height: px(200);
+      height: px(300);
 
       overflow-y: scroll;
 
       @include mq-large {
         width: px(960);
-        height: px(200);
+        height: px(300);
       }
     }
   }


### PR DESCRIPTION
凍結状態だったNews欄を資料集約用の欄としてリニューアルしました。

- news.ymlそのものは保持
- talks.ymlに過去の発表資料一覧を集約
- News欄をPrevious talks欄に置き換え
- ついでに表示幅を200px->300pxに変更